### PR TITLE
给进程加速做了一个狂拽酷炫叼炸天诸天至尊神魔破灭至高九界吞噬主宰修罗无上混沌幽冥九天十地的升级，整整节省了1̶0̶T̶B̶1̶0̶G̶B̶…

### DIFF
--- a/main.js
+++ b/main.js
@@ -110,6 +110,7 @@ app.whenReady().then(async () => {
   tunManager = new TunManager(proxyServer);
   speedManager = new SpeedManager();
   speedManager.init(app.getAppPath(), mainWindow);
+  proxyServer.speedManager = speedManager;  // 代理在关键请求期间对加速做"网络保护"
   ttsManager.init(app.getAppPath(), mainWindow, rulesManager);
 
   windowManager.registerIpcHandlers();

--- a/modules/proxy.js
+++ b/modules/proxy.js
@@ -42,6 +42,7 @@ class ProxyServer {
     this.fillTimeMod = { enabled: false, seconds: null };
     this.FILL_TIME_SALT = 'submitTaskToken-pc-987654'; // 与听力共用同一服务端盐值
     this.mainWindow = null;
+    this.speedManager = null;  // 由 main.js 注入; 用于关键请求期间瞬时降速(网络保护)
     this.trafficCache = new Map();
     this.serverDatas = {};
     this.isStopping = false;
@@ -60,6 +61,25 @@ class ProxyServer {
     this._progressWindowReady = false;
   }
 
+  // ===== 进程加速"网络保护" =====
+  // 关键 up366 请求在飞期间, 把加速倍率瞬时压回 1×(引用计数), 响应结束/出错再恢复,
+  // 避免加速把 renderer 的请求超时按倍率缩短 → 题目进不去/交卷失败。时钟污染不在此列。
+  _speedHold(ctx) {
+    const sm = this.speedManager;
+    if (!sm || !sm.enabled || !ctx || ctx._speedHeld) return;
+    const host = (ctx.clientToProxyRequest && ctx.clientToProxyRequest.headers
+                  && ctx.clientToProxyRequest.headers.host) || '';
+    if (!/up366/i.test(host)) return;   // 只保护天学网自身请求
+    ctx._speedHeld = true;
+    sm.netHold();
+  }
+
+  _speedRelease(ctx) {
+    if (!ctx || !ctx._speedHeld) return;
+    ctx._speedHeld = false;
+    if (this.speedManager) this.speedManager.netRelease();
+  }
+
   // 启动代理服务器
   startProxyPromise() {
     return new Promise((resolve) => {
@@ -69,7 +89,8 @@ class ProxyServer {
       // 创建新的代理实例
       this.proxy = new Proxy();
 
-      this.proxy.onError(function (ctx, err) {
+      this.proxy.onError((ctx, err) => {
+        this._speedRelease(ctx);  // 网络保护: 请求出错也要恢复加速, 防止卡在 1×
         console.error('代理出错:', err);
       });
 
@@ -92,6 +113,10 @@ class ProxyServer {
         if (!isAnswerCaptureEnabled) {
           return callback();
         }
+
+        // 进程加速网络保护: 该 up366 请求在飞期间把倍率瞬时压回 1×, 响应结束再恢复,
+        // 避免加速把 renderer 请求超时掐断(题目进不去/交卷失败)。与下方 onResponseEnd 配对。
+        this._speedHold(ctx);
 
         let requestBody = [], responseBody = [];
         const hasPostChangeTimeRule = this.getPostChangeTimeRules(fullUrl, ctx.clientToProxyRequest.method).length > 0;
@@ -253,6 +278,7 @@ class ProxyServer {
           else return callback(null, chunk);
         })
         ctx.onResponseEnd(async (ctx, callback) => {
+          this._speedRelease(ctx);  // 网络保护: 响应结束, 恢复加速
           let { buffer, text, decompressFailed } = await this.decompressBuffer(Buffer.concat(responseBody), ctx.serverToProxyResponse.headers['content-encoding']);
           if (responseBodyRules.includes(2)) {
             buffer = this.applyZipImplantRules(fullUrl, buffer);

--- a/modules/speed-manager.js
+++ b/modules/speed-manager.js
@@ -2,7 +2,8 @@
  * SpeedManager —— 进程加速管理器 (主进程侧)
  * ------------------------------------------------------------
  * 职责:
- *   - 常驻管理 injector64.exe 子进程(纯 C 注入器, 复用 OpenSpeedy 的 speedpatch64.dll)
+ *   - 常驻管理 injector32.exe 子进程(纯 C 注入器, 复用 OpenSpeedy 的 speedpatch32.dll;
+ *     up366 是 32 位, 只能 32 位注入; 注入器默认只注入 renderer 进程)
  *   - 接收「进程加速」页面经 IPC 推来的倍率(set-speed / reset-speed)
  *   - 通过 stdin 把 "speed <factor>" / "reset" 命令喂给注入器
  *   - 注入器内部自行枚举 up366.exe 全部进程并注入, 无需主进程传 pid
@@ -14,12 +15,12 @@
  *   - 生命周期挂在 main.js: app ready 时 init, before-quit 时 stop
  *
  * 依赖文件(随 Auto366 分发, 放在 resources/openspeedy/):
- *   - injector64.exe     本仓库 openspeedy/injector.c 编译产物
- *   - speedpatch64.dll   取自 OpenSpeedy(导出 SP_SetSpeed/SP_Enable)
+ *   - injector32.exe     本仓库 openspeedy/injector.c 编译产物(默认只注入 renderer)
+ *   - speedpatch32.dll   取自 OpenSpeedy(导出 SP_SetSpeed/SP_Enable)
  *
  * 关键前置:
  *   - Auto366 必须以管理员权限运行(注入需要), 注入器继承该权限
- *   - injector64.exe 与 speedpatch64.dll 必须在同一目录
+ *   - injector32.exe 与 speedpatch32.dll 必须在同一目录
  *   - 该目录路径不能含中文(LoadLibraryW 的 ASCII 回退在中文路径下会失败)
  */
 
@@ -38,6 +39,12 @@ class SpeedManager {
     // 当前期望状态(面板推来的)
     this.enabled = false;
     this.factor = null; // null = 未设置
+
+    // 网络保护: 关键请求在飞期间把倍率瞬时压回 1×(引用计数, 可并发)
+    this._netHolds = 0;
+    this._netActive = false;  // 是否已向注入器发过 hold(用于配对 resume)
+    this._netSafetyTimer = null;
+    this._lastDesired = null; // 去重, 避免重复下发相同 speed/reset
 
     // 注入器文件所在目录
     this.baseDir = null;
@@ -71,7 +78,7 @@ class SpeedManager {
       const root = process.env.ProgramData || 'C:\\ProgramData';
       const dest = path.join(root, 'Auto366', 'openspeedy');
       fs.mkdirSync(dest, { recursive: true });
-      const files = ['injector32.exe', 'speedpatch32.dll', 'injector64.exe', 'speedpatch64.dll'];
+      const files = ['injector32.exe', 'speedpatch32.dll'];
       for (const name of files) {
         const src = path.join(this.baseDir, name);
         if (fs.existsSync(src)) fs.copyFileSync(src, path.join(dest, name));
@@ -117,11 +124,11 @@ class SpeedManager {
       return false;
     }
     if (!fs.existsSync(this.injectorPath)) {
-      this._log('缺少 injector64.exe: ' + this.injectorPath, 'error');
+      this._log('缺少 injector32.exe: ' + this.injectorPath, 'error');
       return false;
     }
     if (!fs.existsSync(this.dllPath)) {
-      this._log('缺少 speedpatch64.dll: ' + this.dllPath, 'error');
+      this._log('缺少 speedpatch32.dll: ' + this.dllPath, 'error');
       return false;
     }
     // 含中文路径会导致 LoadLibrary ASCII 回退失败
@@ -173,6 +180,11 @@ class SpeedManager {
       this.child = null;
       this.ready = false;
       this.starting = false;
+      this._lastDesired = null;
+      this._netHolds = 0;
+      this._netActive = false;
+      clearTimeout(this._netSafetyTimer);
+      this._netSafetyTimer = null;
     });
 
     this.child.on('error', (err) => {
@@ -180,6 +192,11 @@ class SpeedManager {
       this.child = null;
       this.ready = false;
       this.starting = false;
+      this._lastDesired = null;
+      this._netHolds = 0;
+      this._netActive = false;
+      clearTimeout(this._netSafetyTimer);
+      this._netSafetyTimer = null;
     });
 
     return true;
@@ -264,13 +281,45 @@ class SpeedManager {
     }
   }
 
-  // 根据当前期望状态(enabled/factor)下发命令
+  // 根据当前期望状态(enabled/factor/网络保护)下发命令。
+  // 网络保护激活(_netHolds>0)时一律 reset(1×); 去重避免频繁 hold/release 刷屏。
   _applyDesired() {
     if (!this.ready) return;
-    if (this.enabled && this.factor && this.factor > 0) {
-      this._send('speed ' + this.factor);
-    } else {
-      this._send('reset');
+    const cmd = (this.enabled && this.factor && this.factor > 0)
+      ? ('speed ' + this.factor)
+      : 'reset';
+    if (cmd === this._lastDesired) return;
+    this._lastDesired = cmd;
+    this._send(cmd);
+  }
+
+  // 网络保护: 关键请求开始 → 发轻量 hold 压回 1×(引用计数, 仅加速中且就绪才发)
+  netHold() {
+    this._netHolds++;
+    if (this._netHolds === 1 && this.enabled && this.ready) {
+      this._netActive = true;
+      this._send('hold');
+      // 兜底: 万一某请求漏配对 release, 20s 后强制 resume, 防止卡在 1×
+      clearTimeout(this._netSafetyTimer);
+      this._netSafetyTimer = setTimeout(() => {
+        if (this._netHolds > 0) {
+          this._log('网络保护超时(20s), 强制恢复加速', 'warning');
+          this._netHolds = 0;
+          if (this._netActive) { this._netActive = false; this._send('resume'); }
+        }
+      }, 20000);
+    }
+  }
+
+  // 网络保护: 关键请求结束/出错 → 发 resume 恢复目标倍率(引用计数归零且发过 hold 才恢复)
+  netRelease() {
+    if (this._netHolds <= 0) return;
+    this._netHolds--;
+    if (this._netHolds === 0 && this._netActive) {
+      this._netActive = false;
+      clearTimeout(this._netSafetyTimer);
+      this._netSafetyTimer = null;
+      this._send('resume');
     }
   }
 
@@ -295,8 +344,8 @@ class SpeedManager {
       // 若正在启动, READY 回调里会补发
       return { success: true };
     } else {
-      // 关闭加速: 若注入器在跑则恢复 1.0(不杀进程, 便于下次快速再开)
-      if (this.ready) this._send('reset');
+      // 关闭加速: 恢复 1.0(不杀进程, 便于下次快速再开)。经 _applyDesired 统一去重下发。
+      this._applyDesired();
       return { success: true };
     }
   }


### PR DESCRIPTION
…1̶0̶M̶B̶1̶0̶K̶B̶（好吧我并不知道），并测试了很多遍（我希望是真的），没有发现哪怕一个bug(至少在一种语境下是成立的，嗯)！

- 进程加速"网络保护": 代理拦到关键 up366 请求期间, 经 SpeedManager 发 hold 把倍率瞬时压回 1×, 响应结束/出错发 resume 恢复(引用计数 + 20s 兜底), 修复"加速+规则集→题目进不去/交卷失败"。 hold/resume 为注入器轻量静默命令, 不刷屏、不重复枚举进程。
- SpeedManager 改用 32 位注入器并默认只注入 renderer(见 openspeedy/injector.c, 该目录被 .gitignore 故未随此提交), 修复"未进入题目时开加速→页面卡死"; 注入器 -Os -s 瘦身至 ~70KB, 删除从未使用的 64 位注入器与 speedpatch64.dll。
- 时钟污染(高倍率长时使 renderer 时钟永久超前)无法在注入层根治, 需用户控制倍率。